### PR TITLE
Ignores aferox dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,8 @@
   "timezone": "America/Chicago",
   "schedule": [
     "before 4am on the first day of the month"
+  ],
+  "ignoreDeps": [
+    "github.com/unmango/aferox"
   ]
 }


### PR DESCRIPTION
Configures Renovate to ignore updates to the aferox dependency.

This prevents unnecessary updates and potential conflicts
related to this specific dependency.
