### PR TITLE
Fixes rooted path matching in mapped filesystem

### DIFF
--- a/mapped/fs.go
+++ b/mapped/fs.go
@@ -2,8 +2,8 @@ package mapped
 
 import (
 	"fmt"
-	"maps"
 	"os"
+	"path"
 	"time"
 
 	"github.com/spf13/afero"
@@ -14,7 +14,7 @@ type Fs map[string]afero.Fs
 func NewFs(m map[string]afero.Fs) afero.Fs {
 	fs := Fs{}
 	for k, v := range m {
-		fs[Clean(k)] = v
+		fs[path.Clean(k)] = v
 	}
 
 	return fs
@@ -130,7 +130,8 @@ func (f Fs) Stat(name string) (os.FileInfo, error) {
 }
 
 func (f Fs) split(name string) (key, path string, err error) {
-	for k := range maps.Keys(f) {
+	for k := range f {
+		fmt.Println("Name: ", name)
 		if p, ok := CutPrefix(name, k); ok {
 			return k, p, nil
 		}

--- a/mapped/fs.go
+++ b/mapped/fs.go
@@ -131,7 +131,6 @@ func (f Fs) Stat(name string) (os.FileInfo, error) {
 
 func (f Fs) split(name string) (key, path string, err error) {
 	for k := range f {
-		fmt.Println("Name: ", name)
 		if p, ok := CutPrefix(name, k); ok {
 			return k, p, nil
 		}

--- a/mapped/fs_test.go
+++ b/mapped/fs_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Fs", func() {
 			"test": testFs,
 		})
 
-		f, err := fs.Open("test/test.txt")
+		f, err := fs.Open("/test/test.txt")
 
 		Expect(err).NotTo(HaveOccurred())
 		data, err := io.ReadAll(f)
@@ -76,7 +76,7 @@ var _ = Describe("Fs", func() {
 
 	It("should match rooted paths", func() {
 		testFs := afero.NewMemMapFs()
-		err := afero.WriteFile(testFs, "test.txt", []byte(""), os.ModePerm)
+		err := afero.WriteFile(testFs, "/test.txt", []byte(""), os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 		fs := mapped.NewFs(map[string]afero.Fs{
 			"test": testFs,

--- a/mapped/fs_test.go
+++ b/mapped/fs_test.go
@@ -28,6 +28,22 @@ var _ = Describe("Fs", func() {
 		Expect(string(data)).To(Equal("testing"))
 	})
 
+	It("should open a file at the root of the nested fs", func() {
+		testFs := afero.NewMemMapFs()
+		err := afero.WriteFile(testFs, "/test.txt", []byte("testing"), os.ModePerm)
+		Expect(err).NotTo(HaveOccurred())
+		fs := mapped.NewFs(map[string]afero.Fs{
+			"test": testFs,
+		})
+
+		f, err := fs.Open("test/test.txt")
+
+		Expect(err).NotTo(HaveOccurred())
+		data, err := io.ReadAll(f)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("testing"))
+	})
+
 	It("should open a file in an fs with multiple path segments", func() {
 		testFs := afero.NewMemMapFs()
 		err := afero.WriteFile(testFs, "test.txt", []byte("testing"), os.ModePerm)

--- a/mapped/path.go
+++ b/mapped/path.go
@@ -5,13 +5,9 @@ import (
 	"strings"
 )
 
-func Clean(p string) string {
-	return strings.TrimLeft(path.Clean(p), "/")
-}
-
 func CutPrefix(s, prefix string) (after string, found bool) {
-	if after, found = strings.CutPrefix(Clean(s), prefix); found {
-		return Clean(after), found
+	if after, found = strings.CutPrefix(path.Clean(s), prefix); found {
+		return path.Clean(after), found
 	}
 
 	return

--- a/mapped/path.go
+++ b/mapped/path.go
@@ -1,14 +1,20 @@
 package mapped
 
 import (
+	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
 func CutPrefix(s, prefix string) (after string, found bool) {
-	if after, found = strings.CutPrefix(path.Clean(s), prefix); found {
-		return path.Clean(after), found
+	if after, found = strings.CutPrefix(s, prefix); !found {
+		return
 	}
 
-	return
+	if path.IsAbs(s) {
+		return fmt.Sprint(filepath.Separator, after), true
+	} else {
+		return after, true
+	}
 }

--- a/mapped/path.go
+++ b/mapped/path.go
@@ -1,20 +1,20 @@
 package mapped
 
 import (
-	"fmt"
-	"path"
-	"path/filepath"
 	"strings"
 )
 
 func CutPrefix(s, prefix string) (after string, found bool) {
+	prefix = strings.TrimLeft(prefix, "/")
+	s, abs := strings.CutPrefix(s, "/")
+
 	if after, found = strings.CutPrefix(s, prefix); !found {
 		return
 	}
 
-	if path.IsAbs(s) {
-		return fmt.Sprint(filepath.Separator, after), true
-	} else {
+	if abs {
 		return after, true
+	} else {
+		return strings.TrimLeft(after, "/"), true
 	}
 }

--- a/mapped/path_test.go
+++ b/mapped/path_test.go
@@ -1,0 +1,24 @@
+package mapped_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/unmango/aferox/mapped"
+)
+
+var _ = Describe("Path", func() {
+	FDescribe("CutPrefix", func() {
+		DescribeTable("should cut matching prefixes",
+			func(s, prefix, expected string) {
+				actual, found := mapped.CutPrefix(s, prefix)
+
+				Expect(found).To(BeTrueBecause("The prefix was found"))
+				Expect(actual).To(Equal(expected))
+			},
+			Entry(nil, "test/test.txt", "test", "/test.txt"),
+			Entry(nil, "/test/test.txt", "/test", "/test.txt"),
+			Entry(nil, "test/test.txt", "/test", "/test.txt"),
+		)
+	})
+})

--- a/mapped/path_test.go
+++ b/mapped/path_test.go
@@ -10,15 +10,16 @@ import (
 var _ = Describe("Path", func() {
 	FDescribe("CutPrefix", func() {
 		DescribeTable("should cut matching prefixes",
-			func(s, prefix, expected string) {
+			func(prefix, s, expected string) {
 				actual, found := mapped.CutPrefix(s, prefix)
 
 				Expect(found).To(BeTrueBecause("The prefix was found"))
 				Expect(actual).To(Equal(expected))
 			},
-			Entry(nil, "test/test.txt", "test", "/test.txt"),
-			Entry(nil, "/test/test.txt", "/test", "/test.txt"),
-			Entry(nil, "test/test.txt", "/test", "/test.txt"),
+			Entry(nil, "test", "test/test.txt", "test.txt"),
+			Entry(nil, "test", "/test/test.txt", "/test.txt"),
+			Entry(nil, "/test", "test/test.txt", "test.txt"),
+			Entry(nil, "/test", "/test/test.txt", "/test.txt"),
 		)
 	})
 })

--- a/mapped/path_test.go
+++ b/mapped/path_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Path", func() {
-	FDescribe("CutPrefix", func() {
+	Describe("CutPrefix", func() {
 		DescribeTable("should cut matching prefixes",
 			func(prefix, s, expected string) {
 				actual, found := mapped.CutPrefix(s, prefix)


### PR DESCRIPTION
Corrects how the mapped filesystem handles rooted paths.

- Ensures that rooted paths are correctly matched and resolved within the nested filesystems.
- Adds test cases to verify the fix and prevent regressions.
- Improves the `CutPrefix` function to handle leading slashes in both the search string and the prefix.